### PR TITLE
update fileExistsSync to not use fs.accessSync

### DIFF
--- a/lib/ttb-util.js
+++ b/lib/ttb-util.js
@@ -73,8 +73,8 @@ function joinAndCreatePath(pathList) {
 
 function fileExistsSync(path) {
     try {
-        fs.accessSync(path);
-        return true;
+        var stats = fs.statSync(path);
+        return (stats && stats.isDirectory());
     } catch (e) {
         return false;
     }


### PR DESCRIPTION
fs.accessSync doesn't seem to work in VS.
Addresses issue 14 (https://github.com/Microsoft/taco-team-build/issues/14)

@Chuxel @lostintangent 