### PR TITLE
Fix for disabling addSupportPlugin

### DIFF
--- a/lib/ttb-util.js
+++ b/lib/ttb-util.js
@@ -126,24 +126,24 @@ function parseConfig(newCfg, currentCfg) {
     if (!newCfg) return (currentCfg);
     
     // Path to module cache
-    if (newCfg.moduleCache) {
+    if (newCfg.hasOwnProperty('moduleCache')) {
         setCachePath(joinAndCreatePath(path.resolve(newCfg.moduleCache)));
     }
     
     // Version of node module to use
-    if (newCfg.moduleVersion) currentCfg.moduleVersion = newCfg.moduleVersion;
+    if (newCfg.hasOwnProperty('moduleVersion')) currentCfg.moduleVersion = newCfg.moduleVersion;
 
     // Inidcates whether the cordova node module should be loaded after its cached - must be false to use buldProject
-    if (newCfg.loadCordovaModule) currentCfg.loadCordovaModule = newCfg.loadCordovaModule;
+    if (newCfg.hasOwnProperty('loadCordovaModule')) currentCfg.loadCordovaModule = newCfg.loadCordovaModule;
     
     // Inidcates whether support plugin should be installed
-    if (newCfg.addSupportPlugin) currentCfg.addSupportPlugin = newCfg.addSupportPlugin;
+    if (newCfg.hasOwnProperty('addSupportPlugin')) currentCfg.addSupportPlugin = newCfg.addSupportPlugin;
 
     // Allows use of other Cordova CLI style modules when caching only
-    if (newCfg.nodePackageName) currentCfg.nodePackageName = newCfg.nodePackageName;
+    if (newCfg.hasOwnProperty('nodePackageName')) currentCfg.nodePackageName = newCfg.nodePackageName;
 
     // Project path if not cwd
-    if (newCfg.projectPath) {
+    if (newCfg.hasOwnProperty('projectPath')) {
         currentCfg.projectPath = path.resolve(newCfg.projectPath);
         if (!fileExistsSync(currentCfg.projectPath)) {
             throw 'Specified project path does not exist: "' + currentCfg.projectPath + '"';


### PR DESCRIPTION
Fixed code for disabling the addSupportPlugin. 

When in configure `{ addSupportPlugin: false }` is passed, the current LOC `newCfg.addSupportPlugin` will turn out to be false and the code `currentCfg.addSupportPlugin = newCfg.addSupportPlugin;` will never be executed.