### PR TITLE
Fix taco.json and args parsing

### DIFF
--- a/lib/ttb-util.js
+++ b/lib/ttb-util.js
@@ -96,7 +96,8 @@ function getCallArgs(platforms, args, cordovaVersion) {
     
     // 5.4.0 changes the way arguments are passed to build. Rather than just having an array
     // of options, it needs to be an object with an "argv" member for the arguments.
-    // This change was reverted in 6.0.0
+    // A change was added in 6.0.0 that required the new format to be more complete.
+    // Workaround for now is to use the old way that 6.0.0 has a fallback for.
     if (semver.valid(cordovaVersion) && semver.gte(cordovaVersion, '5.4.0') && semver.lt(cordovaVersion, '6.0.0')) {
         return { platforms: platforms, options: { argv: options } };
     } else {

--- a/lib/ttb-util.js
+++ b/lib/ttb-util.js
@@ -96,7 +96,8 @@ function getCallArgs(platforms, args, cordovaVersion) {
     
     // 5.4.0 changes the way arguments are passed to build. Rather than just having an array
     // of options, it needs to be an object with an "argv" member for the arguments.
-    if (semver.valid(cordovaVersion) && semver.gte(cordovaVersion, '5.4.0')) {
+    // This change was reverted in 6.0.0
+    if (semver.valid(cordovaVersion) && semver.gte(cordovaVersion, '5.4.0') && semver.lt(cordovaVersion, '6.0.0')) {
         return { platforms: platforms, options: { argv: options } };
     } else {
         return { platforms: platforms, options: options };

--- a/lib/ttb-util.js
+++ b/lib/ttb-util.js
@@ -74,7 +74,7 @@ function joinAndCreatePath(pathList) {
 function fileExistsSync(path) {
     try {
         var stats = fs.statSync(path);
-        return (stats && stats.isDirectory());
+        return (stats && stats.isFile());
     } catch (e) {
         return false;
     }

--- a/lib/ttb-util.js
+++ b/lib/ttb-util.js
@@ -74,7 +74,7 @@ function joinAndCreatePath(pathList) {
 function fileExistsSync(path) {
     try {
         var stats = fs.statSync(path);
-        return (stats && stats.isFile());
+        return (stats && (stats.isFile() || stats.isDirectory()));
     } catch (e) {
         return false;
     }

--- a/taco-team-build.js
+++ b/taco-team-build.js
@@ -136,7 +136,8 @@ function prepareProject(cordovaPlatforms, args, /* optional */ projectPath) {
             promise = promise.then(function () {
                 // Build app with platform specific args if specified
                 var callArgs = utilities.getCallArgs(platform, args);
-                console.log('Queueing prepare for platform ' + platform + ' w/options: ' + callArgs.options || 'none');
+                var argsString = _getArgsString(callArgs);
+                console.log('Queueing prepare for platform ' + platform + ' w/options: ' +argsString);
                 return cordova.raw.prepare(callArgs);
             });
         });
@@ -191,7 +192,7 @@ function buildProject(cordovaPlatforms, args, /* optional */ projectPath) {
             promise = promise.then(function () {
                 // Build app with platform specific args if specified
                 var callArgs = utilities.getCallArgs(platform, args, cordovaVersion);
-                var argsString = _getArgsString(args.options);
+                var argsString = _getArgsString(callArgs);
                 console.log('Queueing build for platform ' + platform + ' w/options: ' + argsString);
                 return cordova.raw.build(callArgs);
             });

--- a/taco-team-build.js
+++ b/taco-team-build.js
@@ -136,7 +136,7 @@ function prepareProject(cordovaPlatforms, args, /* optional */ projectPath) {
             promise = promise.then(function () {
                 // Build app with platform specific args if specified
                 var callArgs = utilities.getCallArgs(platform, args);
-                var argsString = _getArgsString(callArgs);
+                var argsString = _getArgsString(callArgs.options);
                 console.log('Queueing prepare for platform ' + platform + ' w/options: ' +argsString);
                 return cordova.raw.prepare(callArgs);
             });
@@ -192,7 +192,7 @@ function buildProject(cordovaPlatforms, args, /* optional */ projectPath) {
             promise = promise.then(function () {
                 // Build app with platform specific args if specified
                 var callArgs = utilities.getCallArgs(platform, args, cordovaVersion);
-                var argsString = _getArgsString(callArgs);
+                var argsString = _getArgsString(callArgs.options);
                 console.log('Queueing build for platform ' + platform + ' w/options: ' + argsString);
                 return cordova.raw.build(callArgs);
             });


### PR DESCRIPTION
A bug in the fileExists check was not actually checking if the file existed.
Cordova 6.0.0 reverted the args parse change that was introduced in 5.4.x.

This change fixes both of these issues. Addresses issue https://github.com/Microsoft/taco-team-build/issues/18

@BretJohnson @Chuxel @lostintangent 