### PR TITLE
Fix cache initialization

### DIFF
--- a/lib/ttb-util.js
+++ b/lib/ttb-util.js
@@ -60,7 +60,10 @@ function ensurePathExists(resolvedPath) {
 function joinAndCreatePath(pathList) {
     var outPath;
     pathList.forEach(function (relPath) {
-        if (relPath === '') relPath = path.sep;
+        // Make sure to reappend the root if we need to
+        if (relPath === '') relPath = path.sep; // *NIX root
+        if (relPath.indexOf(':') >= 0) relPath += path.sep; // Windows root
+
         if (!outPath) {
             outPath = relPath;
         } else {


### PR DESCRIPTION
The problem here was that joinAndCreatePath was not creating the right paths on Windows, leading to a cache directory that didn't exist.
This was due to node path.resolve assuming that the string "C:" was a relative path and not a rooted path, making the joinAndCreatePath resolution create a bunch of directories relative to the cwd.

Fix here is to update joinAndCreatePath to properly reappend root.

@Chuxel @lostintangent @BretJohnson 