### PR TITLE
Fix setting cache path in configure

### DIFF
--- a/lib/ttb-util.js
+++ b/lib/ttb-util.js
@@ -166,7 +166,7 @@ function parseConfig(newCfg, currentCfg) {
     
     // Path to module cache
     if (newCfg.hasOwnProperty('moduleCache')) {
-        setCachePath(joinAndCreatePath(path.resolve(newCfg.moduleCache)));
+        setCachePath(path.resolve(newCfg.moduleCache));
     }
     
     // Version of node module to use


### PR DESCRIPTION
Fixing a bug in setting the cache path from the configuration (https://github.com/Microsoft/taco-team-build/issues/24)

We were trying to ensure the directory existed multiple times when setting the cache from the passed in configuration object. Removing the duplicate ensure call fixes this.

@Chuxel @BretJohnson 