### PR TITLE
Set CI flag

### DIFF
--- a/taco-team-build.js
+++ b/taco-team-build.js
@@ -309,6 +309,7 @@ module.exports = {
     getVersionForNpmPackage: utilities.getVersionForNpmPackage,
     getNpmVersionFromConfig: getNpmVersionFromConfig,
     cacheModule: function (config) {
+        process.env["CI"]=true;
         config = utilities.parseConfig(config, defaultConfig);
         return cache.cacheModule(config);
     }


### PR DESCRIPTION
Cordova 6.2.0 will block on waiting on a user input on first time run for telemetry.
Setting env var CI to true disables this behaviour.

@Chuxel 