### PR TITLE
Add xcode8 support message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taco-team-build",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "taco-team-build is a node module designed to avoid common pitfalls when building Cordova apps in a Team or Continuous Integration environment. It was put together for a set of tutorials for the Visual Studio 2015 Tools for Apache Cordova (TACo) featureset in Visual Studio but can be used with standard cordova projects.",
   "author": "Microsoft <vscordovatools@microsoft.com>",
   "contributors": [

--- a/taco-team-build.js
+++ b/taco-team-build.js
@@ -150,7 +150,7 @@ function ensureProjectXcode8Compatibility(projectPath, platform, callArgs) {
             }
 
             if (cordovaIosVersion && semver.lt(cordovaIosVersion.version, '4.3.0')) {
-                throw new Error('Your cordova-ios version is ' + v.version + '. Xcode8 requires cordova-ios 4.3.0 or above. Please update.');
+                throw new Error('Your cordova-ios version is ' + cordovaIosVersion.version + '. Xcode8 requires cordova-ios 4.3.0 or above. Please update.');
             }
 
             // check build.json existence


### PR DESCRIPTION
To work with Xcode 8 or above, the project must have:

1. cordova-ios 4.3.0 or later
2. specify a build.json file as described in https://taco.visualstudio.com/en-us/docs/vs-taco-2017-ios-guide/#xcode8

This PR is going to supply the necessary error message to direct user to make corresponding actions.